### PR TITLE
Add new flags for auto-lease and break-lease

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+module/.*
+module/Module*
+module/dysk.ko
+*mod.c
+*vendor*
+*.o*
+dyskctl/dyskctl
+

--- a/dyskctl/Gopkg.lock
+++ b/dyskctl/Gopkg.lock
@@ -4,14 +4,19 @@
 [[projects]]
   name = "github.com/Azure/azure-sdk-for-go"
   packages = ["storage"]
-  revision = "934e2462aeb6e0c14186dcfeedd73a026d1b8eeb"
-  version = "v12.1.0-beta"
+  revision = "eae258195456be76b2ec9ad2ee2ab63cdda365d9"
+  version = "v12.2.0-beta"
 
 [[projects]]
   name = "github.com/Azure/go-autorest"
-  packages = ["autorest","autorest/adal","autorest/azure","autorest/date"]
-  revision = "809ed2ef5c4c9a60c3c2f3aa9cc11f3a7c2ce59d"
-  version = "v9.6.0"
+  packages = [
+    "autorest",
+    "autorest/adal",
+    "autorest/azure",
+    "autorest/date"
+  ]
+  revision = "8c58b4788dedd95779efe0ac2055bb6a1b9b8e01"
+  version = "v9.7.0"
 
 [[projects]]
   name = "github.com/dgrijalva/jwt-go"
@@ -22,13 +27,23 @@
 [[projects]]
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
-  revision = "629574ca2a5df945712d3079857300b5e4da0236"
-  version = "v1.4.2"
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  version = "v1.4.7"
 
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
   revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
 
 [[projects]]
@@ -41,13 +56,18 @@
   branch = "master"
   name = "github.com/khenidak/dysk"
   packages = ["pkg/client"]
-  revision = "12b8330801c186f75b18ac2126c01a0c739c509d"
+  revision = "6e14ea59a5404a8eb6e864485005f1b61a207ba0"
 
 [[projects]]
   name = "github.com/magiconair/properties"
   packages = ["."]
   revision = "d419a98cdbed11a922bf76f257b7c4be79b50e73"
   version = "v1.7.4"
+
+[[projects]]
+  name = "github.com/marstr/guid"
+  packages = ["."]
+  revision = "8bdf7d1a087ccc975cf37dd6507da50698fd19ca"
 
 [[projects]]
   branch = "master"
@@ -75,7 +95,10 @@
 
 [[projects]]
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem"
+  ]
   revision = "ec3a3111d1e1bdff38a61e09d5a5f5e974905611"
   version = "v1.0.1"
 
@@ -95,7 +118,7 @@
   branch = "master"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
-  revision = "12bd96e66386c1960ab0f74ced1362f66f552f7b"
+  revision = "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394"
 
 [[projects]]
   name = "github.com/spf13/pflag"
@@ -113,19 +136,26 @@
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "a3f2cbd54cf5dfe3fbaccf76375fdb12f67654c8"
+  revision = "810d7000345868fc619eb81f46307107118f4ae1"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
+  packages = [
+    "internal/gen",
+    "internal/triegen",
+    "internal/ucd",
+    "transform",
+    "unicode/cldr",
+    "unicode/norm"
+  ]
   revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
 
 [[projects]]
   branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "0e4404da71227dcc02fb1deee803d93e86d08f72"
+  revision = "d670f9405373e636a5a2765eea47fac0c9bc91a4"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/dyskctl/Gopkg.toml
+++ b/dyskctl/Gopkg.toml
@@ -36,3 +36,4 @@
 [[constraint]]
   name = "github.com/spf13/viper"
   version = "1.0.0"
+

--- a/dyskctl/Makefile
+++ b/dyskctl/Makefile
@@ -3,6 +3,8 @@ binary := dyskctl
 .PHONY: build
 build: authors
 	@echo "Building..."
+	$Q cp -Rf cmd vendor/github.com/khenidak/dysk/dyskctl/
+	$Q cp -Rf main.go vendor/github.com/khenidak/dysk/dyskctl/
 	$Q CGO_ENABLED=0 go build .
 
 .PHONY: clean deps

--- a/dyskctl/Makefile
+++ b/dyskctl/Makefile
@@ -5,6 +5,7 @@ build: authors
 	@echo "Building..."
 	$Q cp -Rf cmd vendor/github.com/khenidak/dysk/dyskctl/
 	$Q cp -Rf main.go vendor/github.com/khenidak/dysk/dyskctl/
+	$Q cp -Rf ../pkg/client vendor/github.com/khenidak/dysk/pkg/
 	$Q CGO_ENABLED=0 go build .
 
 .PHONY: clean deps

--- a/dyskctl/cmd/cmds.go
+++ b/dyskctl/cmd/cmds.go
@@ -23,7 +23,7 @@ var (
 	size         uint
 	vhdFlag      bool
 	readOnlyFlag bool
-        autoLeaseFlag bool
+	autoLeaseFlag bool
 	breakLeaseFlag bool
 
 	autoCreate bool
@@ -149,10 +149,10 @@ func init() {
 	mountCmd.PersistentFlags().StringVarP(&storageAccountKey, "key", "k", "", "Azure storage account key")
 	mountCmd.PersistentFlags().StringVarP(&container, "container-name", "c", "dysks", "Azure storage storage container name)")
 	mountCmd.PersistentFlags().StringVarP(&deviceName, "device-name", "d", "", "block device name. if empty a random name will be used")
-        mountCmd.PersistentFlags().StringVarP(&leaseId, "lease-id", "i", "", "lease id of an existing blob")
+	mountCmd.PersistentFlags().StringVarP(&leaseId, "lease-id", "i", "", "lease id of an existing blob")
 	mountCmd.PersistentFlags().BoolVarP(&vhdFlag, "vhd", "v", true, "writes the vhd footer to the blob page")
 	mountCmd.PersistentFlags().BoolVarP(&readOnlyFlag, "read-only", "r", false, "mount dysk as read only")
-        mountCmd.PersistentFlags().BoolVarP(&autoLeaseFlag, "auto-lease", "l", true, "create lease if not provided")
+	mountCmd.PersistentFlags().BoolVarP(&autoLeaseFlag, "auto-lease", "l", true, "create lease if not provided")
 	mountCmd.PersistentFlags().BoolVarP(&breakLeaseFlag, "break-lease", "b", false, "allow breaking of existing lease")
 
 	// MOUNT CREATE WE NEED SIZE //

--- a/dyskctl/cmd/cmds.go
+++ b/dyskctl/cmd/cmds.go
@@ -24,6 +24,7 @@ var (
 	vhdFlag      bool
 	readOnlyFlag bool
         autoLeaseFlag bool
+	breakLeaseFlag bool
 
 	autoCreate bool
 
@@ -151,7 +152,8 @@ func init() {
         mountCmd.PersistentFlags().StringVarP(&leaseId, "lease-id", "i", "", "lease id of an existing blob")
 	mountCmd.PersistentFlags().BoolVarP(&vhdFlag, "vhd", "v", true, "writes the vhd footer to the blob page")
 	mountCmd.PersistentFlags().BoolVarP(&readOnlyFlag, "read-only", "r", false, "mount dysk as read only")
-        mountCmd.PersistentFlags().BoolVarP(&autoLeaseFlag, "auto-lease", "l", true, "use existing lease")
+        mountCmd.PersistentFlags().BoolVarP(&autoLeaseFlag, "auto-lease", "l", true, "create lease if not provided")
+	mountCmd.PersistentFlags().BoolVarP(&breakLeaseFlag, "break-lease", "b", false, "allow breaking of existing lease")
 
 	// MOUNT CREATE WE NEED SIZE //
 	mountCreateCmd.PersistentFlags().UintVarP(&size, "size", "n", 2, "page blob size gb")

--- a/dyskctl/cmd/cmds.go
+++ b/dyskctl/cmd/cmds.go
@@ -23,6 +23,7 @@ var (
 	size         uint
 	vhdFlag      bool
 	readOnlyFlag bool
+        autoLeaseFlag bool
 
 	autoCreate bool
 
@@ -149,6 +150,7 @@ func init() {
 	mountCmd.PersistentFlags().StringVarP(&deviceName, "device-name", "d", "", "block device name. if empty a random name will be used")
 	mountCmd.PersistentFlags().BoolVarP(&vhdFlag, "vhd", "v", true, "writes the vhd footer to the blob page")
 	mountCmd.PersistentFlags().BoolVarP(&readOnlyFlag, "read-only", "r", false, "mount dysk as read only")
+        mountCmd.PersistentFlags().BoolVarP(&autoLeaseFlag, "auto-lease", "l", true, "use existing lease")
 
 	// MOUNT CREATE WE NEED SIZE //
 	mountCreateCmd.PersistentFlags().UintVarP(&size, "size", "n", 2, "page blob size gb")

--- a/dyskctl/cmd/cmds.go
+++ b/dyskctl/cmd/cmds.go
@@ -148,6 +148,7 @@ func init() {
 	mountCmd.PersistentFlags().StringVarP(&storageAccountKey, "key", "k", "", "Azure storage account key")
 	mountCmd.PersistentFlags().StringVarP(&container, "container-name", "c", "dysks", "Azure storage storage container name)")
 	mountCmd.PersistentFlags().StringVarP(&deviceName, "device-name", "d", "", "block device name. if empty a random name will be used")
+        mountCmd.PersistentFlags().StringVarP(&leaseId, "lease-id", "i", "", "lease id of an existing blob")
 	mountCmd.PersistentFlags().BoolVarP(&vhdFlag, "vhd", "v", true, "writes the vhd footer to the blob page")
 	mountCmd.PersistentFlags().BoolVarP(&readOnlyFlag, "read-only", "r", false, "mount dysk as read only")
         mountCmd.PersistentFlags().BoolVarP(&autoLeaseFlag, "auto-lease", "l", true, "use existing lease")

--- a/dyskctl/cmd/utils.go
+++ b/dyskctl/cmd/utils.go
@@ -52,10 +52,10 @@ func mount() {
 	d.BreakLease = breakLeaseFlag
 
 	err = dyskClient.Mount(&d)
-        if nil != err {
-                printError(err)
-                        os.Exit(1)
-        }
+    if nil != err {
+        printError(err)
+        os.Exit(1)
+    }
 	printDysk(&d)
 }
 

--- a/dyskctl/cmd/utils.go
+++ b/dyskctl/cmd/utils.go
@@ -52,10 +52,10 @@ func mount() {
 	d.BreakLease = breakLeaseFlag
 
 	err = dyskClient.Mount(&d)
-    if nil != err {
-        printError(err)
-        os.Exit(1)
-    }
+	if nil != err {
+		printError(err)
+		os.Exit(1)
+	}
 	printDysk(&d)
 }
 

--- a/dyskctl/cmd/utils.go
+++ b/dyskctl/cmd/utils.go
@@ -49,6 +49,7 @@ func mount() {
 	d.Vhd = vhdFlag
 	d.AutoCreate = autoCreate
 	d.AutoLease = autoLeaseFlag
+	d.BreakLease = breakLeaseFlag
 
 	err = dyskClient.Mount(&d)
         if nil != err {

--- a/dyskctl/cmd/utils.go
+++ b/dyskctl/cmd/utils.go
@@ -47,13 +47,14 @@ func mount() {
 	d.Path = "/" + container + "/" + pageBlobName
 	d.LeaseId = leaseId
 	d.Vhd = vhdFlag
+	d.AutoCreate = autoCreate
+	d.AutoLease = autoLeaseFlag
 
 	err = dyskClient.Mount(&d)
-	if nil != err {
-		printError(err)
-		os.Exit(1)
-	}
-
+        if nil != err {
+                printError(err)
+                        os.Exit(1)
+        }
 	printDysk(&d)
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -33,7 +33,7 @@ type DyskClient interface {
 	Get(name string) (*Dysk, error)
 	List() ([]*Dysk, error)
 	CreatePageBlob(sizeGB uint, container string, pageBlobName string, is_vhd bool) (string, error)
-    LeaseAndValidate(d *Dysk) (string, error)
+	LeaseAndValidate(d *Dysk) (string, error)
 }
 
 type moduleResponse struct {
@@ -67,7 +67,7 @@ func (c *dyskclient) ensureBlobService() error {
 }
 
 func (c *dyskclient) CreatePageBlob(sizeGB uint, container string, pageBlobName string, is_vhd bool) (string, error) {
-        if err := c.ensureBlobService(); nil != err {
+	if err := c.ensureBlobService(); nil != err {
 		return "", err
 	}
 
@@ -237,15 +237,15 @@ func (c *dyskclient) List() ([]*Dysk, error) {
 }
 
 func (c *dyskclient) LeaseAndValidate(d *Dysk) (string, error) {
-    if 0 < len(d.LeaseId) {
-        err := c.validateLease(d)
-        if nil != err {
+	if 0 < len(d.LeaseId) {
+		err := c.validateLease(d)
+		if nil != err {
 			fmt.Println("lease not valid")
 			pageBlob, err := c.get_pageblob(d)
 			if nil != err {
 				return "", err
 			} else {
-		        leaseId, err := c.lease(pageBlob, d.BreakLease)
+				leaseId, err := c.lease(pageBlob, d.BreakLease)
 				if nil != err {
 					return "", err
 				} else {
@@ -255,14 +255,14 @@ func (c *dyskclient) LeaseAndValidate(d *Dysk) (string, error) {
 		} else {
 			return d.LeaseId, nil
 		}
-    } else {
+	} else {
 		fmt.Println("lease id not provided")
 		if d.AutoLease {
 			pageBlob, err := c.get_pageblob(d)
 			if nil != err {
 				return "", err
 			} else {
-		        leaseId, err := c.lease(pageBlob, d.BreakLease)
+				leaseId, err := c.lease(pageBlob, d.BreakLease)
 				if nil != err {
 					return "", err
 				} else {
@@ -385,8 +385,8 @@ func (c *dyskclient) get(deviceName string) (*Dysk, error) {
 }
 
 func (c *dyskclient) lease(pageBlob *storage.Blob, breakLeaseFlag bool) (string, error) {
-    fmt.Println("acquiring new lease")
-    leaseId, err := pageBlob.AcquireLease(-1, "", nil)
+	fmt.Println("acquiring new lease")
+	leaseId, err := pageBlob.AcquireLease(-1, "", nil)
 	if nil != err {
 		if breakLeaseFlag {
 			fmt.Println("break lease")

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -16,7 +16,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/rubiojr/go-vhd/vhd"
 )
-
+kdjfkd
 const (
 	deviceFile = "/dev/dysk"
 	// IOCTL Command Codes

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -16,7 +16,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/rubiojr/go-vhd/vhd"
 )
-kdjfkd
 const (
 	deviceFile = "/dev/dysk"
 	// IOCTL Command Codes
@@ -49,6 +48,7 @@ type dyskclient struct {
 }
 
 func CreateClient(account string, key string) DyskClient {
+        fmt.Println("createclient")
 	c := dyskclient{
 		storageAccountName: account,
 		storageAccountKey:  key,
@@ -67,7 +67,8 @@ func (c *dyskclient) ensureBlobService() error {
 }
 
 func (c *dyskclient) CreatePageBlob(sizeGB uint, container string, pageBlobName string, is_vhd bool) (string, error) {
-	if err := c.ensureBlobService(); nil != err {
+	fmt.Println("create page blob")
+        if err := c.ensureBlobService(); nil != err {
 		return "", err
 	}
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -126,6 +126,7 @@ func (c *dyskclient) closeDeviceFile() error {
 }
 
 func (c *dyskclient) Mount(d *Dysk) error {
+        fmt.Println("Mount funct")
 	if err := c.openDeviceFile(); nil != err {
 		return err
 	}
@@ -137,6 +138,7 @@ func (c *dyskclient) Mount(d *Dysk) error {
 	}
 
 	as_string := dysk2string(d)
+        fmt.Println(as_string)
 	buffer := bufferize(as_string)
 
 	_, _, e := syscall.Syscall(syscall.SYS_IOCTL, c.f.Fd(), IOCTLMOUNTDYSK, uintptr(unsafe.Pointer(&buffer[0])))
@@ -315,6 +317,7 @@ func (c *dyskclient) get(deviceName string) (*Dysk, error) {
 
 func (c *dyskclient) validateLease(d *Dysk) error {
 
+        fmt.Println("validateLease")
 	blobClient := c.blobClient
 	containerPath := path.Dir(d.Path)
 	containerPath = containerPath[1:]

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -23,4 +23,5 @@ type Dysk struct {
 	SizeGB      int
         AutoLease   bool
         AutoCreate  bool
+	BreakLease  bool
 }

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -21,4 +21,6 @@ type Dysk struct {
 	Minor       int
 	Vhd         bool
 	SizeGB      int
+        AutoLease   bool
+        AutoCreate  bool
 }

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -21,7 +21,7 @@ type Dysk struct {
 	Minor       int
 	Vhd         bool
 	SizeGB      int
-        AutoLease   bool
-        AutoCreate  bool
+	AutoLease   bool
+	AutoCreate  bool
 	BreakLease  bool
 }

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,29 @@ RW                              dysk6Hjr5R52                    Yes             
 > When using the auto-create command the client library by default writes the vhd footer for you. This enables you to mount the disk using ARM if needed. You can disable this using the ``` -vhd ``` flag
 > Make sure the storage account supports http (not https)
 
+Mount existing Azure Page Blob (with or without a lease id) 
+```
+sudo dyskctl mount -a {STORAGE ACCOUNT NAME} -k {STORAGE ACCOUNT KEY} -c {CONTAINER NAME} -d {DISK NAME} -i {LEASE ID}
+
+## output
+Type                            Name                            VHD                             SizeGB                          AccountName                     Path
+RW                              dysk1cmwC5uU                    Yes                             2                               dyskdemo                        /dysks/dysk1cmwC5uU.vhd
+```
+
+If you are seeing error `storage: service returned error: StatusCode=409, ErrorCode=LeaseAlreadyPresent, ErrorMessage=There is already a lease present.`, you can set the `--break-lease` flag to `true` to break the existing lease.
+```
+sudo dyskctl mount -a {STORAGE ACCOUNT NAME} -k {STORAGE ACCOUNT KEY} -c {CONTAINER NAME} -d {DISK NAME} -i {LEASE ID} -b true
+
+## output
+lease not valid
+acquiring new lease
+break lease
+Type                            Name                            VHD                             SizeGB                          AccountName                     Path
+RW                              dysk1cmwC5uU                    Yes                             2                               dyskdemo                        /dysks/dysk1cmwC5uU.vhd
+```
+
+> If you do not provide a `--lease-id`, you will most likely need to set the `--break-lease` flag to `true` to break any existing lease on it. Unless it has been previously released.
+
 
 Dysks are block devices, so it can be used using common Linux commands
 


### PR DESCRIPTION
- [x] Allow user to mount an existing blob with valid `--lease-id`
- [x] Allow user to mount an existing blob without any lease id. If no lease, acquire new lease.
- [x] Allow user to mount an existing blob without any lease id and `--auto-lease=true`, return error.
- [x] Allow user to mount an existing blob without any lease id. If there is existing lease, return error.
- [x] Allow user to mount an existing blob without any lease id. If there is existing lease and `--break-lease` is set to `true`, then break lease and acquire new lease.
- [x] Allow user to mount an existing blob with invalid `--lease-id`. Return error.
- [x] Allow user to mount an existing blob with invalid `--lease-id` and `--break-lease` is set to `true`, then break lease and acquire new lease.