### PR TITLE
Increase the severity of several logging statements.

### DIFF
--- a/dyskctl/AUTHORS
+++ b/dyskctl/AUTHORS
@@ -1,4 +1,5 @@
 andyzhangx <xiazhang@microsoft.com>
+Eric Hotinger <erhoting@microsoft.com>
 Johan Burati <joburati@microsoft.com>
 Khaled (Kal) Henidak <khnidk@outlook.com>
 Rita Zhang <rita.z.zhang@gmail.com>

--- a/module/az.c
+++ b/module/az.c
@@ -1182,6 +1182,7 @@ int az_init(void)
 
   return 0;
 }
+
 void az_teardown(void)
 {
   if (tfm_hmac_sha256) crypto_free_shash(tfm_hmac_sha256);


### PR DESCRIPTION
- Increase the severity of several logging statements from `KERN_INFO` to `KERN_ERR` or `KERN_NOTICE` for major events.
- Normalize all logging statements to be `dysk:` instead of `dysk - `.
- Regenerate `AUTHORS` from `make`
- Minor typo fixes