### PR TITLE
add ROX, RWO support for k8s dysk FlexVolume driver

### DIFF
--- a/kubernetes/dysk
+++ b/kubernetes/dysk
@@ -1,191 +1,162 @@
-#!/bin/bash
-
-#set -eo pipefail
-
-# Notes:
-#  - Please install "jq" package before using this driver.
-
-# leases are kept in etcd as config maps and linked to volumes by labels.
-# [read-only] mounting:
-# - if a lease found in etcd use it. if lease is bad /*TODO:!*/
-# -- if not, loop [for x seconds]
-# --- if not create (no breaking of existing lease), then save it in etcd.
-# --- if lease failed (an existing one exists).
-# --- check etcd, if lease found use it.
-# --- if loop failed break lease create new one. /*TODO: Shall we? */
-# [read-write] mounting:
-# - break lease * the assumption is we might be in a split brain cluster *
-# - create new lease, save it in etcd.
-# - use it
-# -- ** this means that if other ro mounts exists, then will break and restart ** --
-# unmounting
-# -- we break lease and attempt to delete the linked lease in etcd.
-
-
-# *** ReadWriteOnce handles that the disk is not mounted rw on multiple nodes ***
+#!/bin/sh
 
 DIR=$(dirname "$(readlink -f "$0")")
 JQ="/usr/bin/jq"
 DYSKCTL=$DIR/dyskctl
-LOG="/var/log/dysk.log"
+LOG="/var/log/dysk-driver.log"
+VER="1.0.0"
 
-# if kubelet running in a container (such the case of aks/acs-engine clsuters) we need to execute
-# the bin directly. And since it has no access to anything other vol, we keep the dyskctl with 
-# the flex vol driver
 usage() {
-  err "Invalid usage. Usage: "
-  err "\t$0 init"
-  err "\t$0 mount <mount dir> <json params>"
-  err "\t$0 unmount <mount dir>"
-  exit 1
+	err "Invalid usage. Usage: "
+	err "\t$0 init"
+	err "\t$0 mount <mount dir> <json params>"
+	err "\t$0 unmount <mount dir>"
+	exit 1
 }
 
 err() {
-  echo $* 1>&2
+	echo $* 1>&2
 }
 
 log() {
-  echo $* >&1
+	echo $* >&1
 }
 
 ismounted() {
-  MOUNT=`findmnt -n ${MNTPATH} 2>/dev/null | cut -d' ' -f1`
-  [ "${MOUNT}" = "${MNTPATH}" ]
+	MOUNT=`findmnt -n ${MNTPATH} 2>/dev/null | cut -d' ' -f1`
+	[ "${MOUNT}" = "${MNTPATH}" ]
 }
 
 mount() {
-  MNTPATH="$1"
-  shift 1 
+	MNTPATH="$1"
 
-  local ACCOUNTNAME="$(echo  "$@" |"$JQ" -r '.["kubernetes.io/secret/accountname"] // empty' | base64 -d)"
-  local ACCOUNTKEY="$(echo "$@" | "$JQ" -r '.["kubernetes.io/secret/accountkey"] // empty' | tr -d '\n' | tr -d ' ' | base64 -d)"
-  local FS_TYPE="$(echo  "$@" |  "$JQ" -r '.["kubernetes.io/fsType"] //empty')"
-  local READ_ONLY="$(echo  "$@" |  "$JQ" -r '.["kubernetes.io/readOnly"] //empty')"
+	ACCOUNTNAME="$(echo "$2"|"$JQ" -r '.["kubernetes.io/secret/accountname"] // empty' | base64 -d)"
+	ACCOUNTKEY="$(echo "$2"|"$JQ" -r '.["kubernetes.io/secret/accountkey"] // empty' | tr -d '\n' | tr -d ' ' | base64 -d)"
+	FS_TYPE="$(echo "$2"|"$JQ" -r '.["kubernetes.io/fsType"] //empty')"
+	READ_WRITE="$(echo "$2"|"$JQ" -r '.["kubernetes.io/readwrite"] //empty')"
 
-  local CONTAINER_NAME="$(echo "$@" | "$JQ" -r '.container //empty')"
-  local BLOB_NAME="$(echo "$@" | "$JQ" -r '.blob //empty')"  
-  local VOL_ACCOUNT_NAME="$(echo "$@" | "$JQ" -r '.accountName //empty')"
+	CONTAINER="$(echo "$2"|"$JQ" -r '.container //empty')"
+	BLOB="$(echo "$2"|"$JQ" -r '.blob //empty')"
 
-  ## ------------------------------
-  ## Beging validation + defaulting
-  ## ------------------------------
-  if [ -z "${VOL_ACCOUNT_NAME}" ] || [ "${ACCOUNTNAME}" != "${VOL_ACCOUNT_NAME}" ]; then
-    echo "ERR: volume is referencing the wrong account name Vol:${VOL_ACCOUNT_NAME} Secret:${ACCOUNTNAME}" >> $LOG
-    errorLog=`tail -n 1 "${LOG}"`
-    err "{\"status\": \"Failure\", \"message\": \"validation failed, error log:${errorLog}\"}"
-    exit 1
-  fi
-  
-  if [ -z "${CONTAINER_NAME}" ] || [ -z "${BLOB_NAME}" ]; then
-    err "{\"status\": \"Failure\", \"message\": \"validation failed, error log:CONTAINER_NAME:"${PAGE_BLOB_PATH}" or CONTAINER_NAME:"${BLOB_NAME}" is empty\"}"
-    exit 1
-  fi
-  
-  if ismounted ; then
-    local devname=`findmnt -n -o SOURCE ${MNTPATH}`
-    log "{\"status\": \"Success\" , \"message\" :  \"log:INF: Mountpoint: ${MNTPATH} has ${devname} already mounted\"}"
-    exit 0
-  fi
+	if [ -z "${CONTAINER}" ]; then
+		echo "`date` ERR: container is empty" >> $LOG
+		errorLog=`tail -n 1 "${LOG}"`
+		err "{\"status\": \"Failure\", \"message\": \"validation failed, error log:${errorLog}\"}"
+		exit 1
+	fi
 
-  # set fs to ext4 if not provided by user
-  if [ -z "${FS_TYPE}" ]; then
-    echo "INF:fstype was empty and will set it to ext4" >>$LOG
-    FS_TYPE="ext4"
-  fi
+	if [ -z "${BLOB}" ]; then
+		echo "`date` ERR: blob is empty" >> $LOG
+		errorLog=`tail -n 1 "${LOG}"`
+		err "{\"status\": \"Failure\", \"message\": \"validation failed, error log:${errorLog}\"}"
+		exit 1
+	fi
 
-  read_only=""
-  if [ "${READ_ONLY}" = "true" ]; then
-    read_only="--read-only"
-  fi
+	if ismounted ; then
+		devname=`findmnt -n -o SOURCE ${MNTPATH}`
+		log "{\"status\": \"Success\" , \"message\":\"log:INF: Mountpoint: ${MNTPATH} has ${devname} already mounted\"}"
+		exit 0
+	fi
 
-  echo "EXEC: mkdir -p ${MNTPATH}" >> $LOG
-  mkdir -p ${MNTPATH} >>$LOG 2>&1
+	# set fs to ext4 if not provided by user
+	if [ -z "${FS_TYPE}" ]; then
+		echo "`date` INF:fstype was empty and will set it to ext4" >>$LOG
+		FS_TYPE="ext4"
+	fi
 
-  lease_command="--auto-lease --break-lease"
-  
-  command_execute="${DYSKCTL}  mount -a "${ACCOUNTNAME}" -k "${ACCOUNTKEY}" --container-name ${CONTAINER_NAME} --pageblob-name ${BLOB_NAME} ${lease_command} ${read_only}"
-  echo "INF: dysk mount command - ${command_execute} " >> $LOG
+	read_only_param=""
+	if [ $READ_WRITE = "ro" ]; then
+		read_only_param="--read-only"
+	fi
 
-  result=$(eval "${command_execute} -o json 2>>${LOG}")
-  diskname=`echo "$result" | "$JQ" -r '.Name //empty'`
-  if [ ${#diskname} -lt 5 ]; then
-    errorLog=`tail -n 1 "${LOG}"`
-    err "{\"status\": \"Failure\", \"message\": \"Failed to DYSKCTL mount auto-create, mountPath:${MNTPATH}, accountname:${ACCOUNTNAME}, error log:${errorLog}\" }"
-    exit 1
-  fi
+	echo "`date` EXEC: mkdir -p ${MNTPATH}" >> $LOG
+	mkdir -p ${MNTPATH} >>$LOG 2>&1
 
-  if [ "${READ_ONLY}" != "true" ]; then
-    #formatting
-    VOLFSTYPE=$(blkid -o udev ${diskname} 2>/dev/null | grep "ID_FS_TYPE" | cut -d"=" -f2 || echo -n "")
-    if [ -z "${VOLFSTYPE}" ]; then
-     echo "INF: disk:${diskname} is not formatted and will be formatted to ${FS_TYPE}" >> $LOG
-     mkfs -t ${FS_TYPE} /dev/${diskname} >/dev/null 2>&1
-     if [ "$?" != "0" ]; then
-       err "{ \"status\": \"Failure\", \"message\": \"Failed to create fs ${FSTYPE} on device ${diskname}\"}"
-       exit 1
-     fi
-    else
-      echo "INF: disk:${diskname} has fstype:${VOLFSTYPE} and will not be formatted" >> $LOG
-    fi
-  fi
+	command_execute="${DYSKCTL} mount -a "${ACCOUNTNAME}" -k "${ACCOUNTKEY}" -c ${CONTAINER} -p ${BLOB} --auto-lease --break-lease ${read_only_param}"
+	# we don't output ACCOUNTKEY here
+	output_comand="${DYSKCTL} mount -a "${ACCOUNTNAME}" -k ... -c ${CONTAINER} -p ${BLOB} --auto-lease --break-lease ${read_only_param}"
+	echo "`date` INF: ${output_comand} " >> $LOG
 
-  #mounting
-  echo "EXEC: /bin/mount /dev/${diskname} "${MNTPATH}"" >>$LOG
-  /bin/mount /dev/$diskname "${MNTPATH}" >>$LOG 2>&1
-  if [ "$?" != "0" ]; then
-    errorLog=`tail -n 1 "${LOG}"`
-    err "{ \"status\": \"Failure\", \"message\": \"Failed to mount device /dev/${diskname} at ${MNTPATH}, accountname:${ACCOUNTNAME}, error log:${errorLog}\"}"
-    exit 1
-  fi
+	result=$(eval "${command_execute} -o json 2>>${LOG}")
+	diskname=`echo "$result" | "$JQ" -r '.Name //empty'`
+	if [ ${#diskname} -lt 5 ]; then
+		errorLog=`tail -n 1 "${LOG}"`
+		err "{\"status\": \"Failure\", \"message\": \"Failed to DYSKCTL mount auto-create, mountPath:${MNTPATH}, accountname:${ACCOUNTNAME}, error log:${errorLog}\" }"
+		exit 1
+	fi
 
-  errorLog=`tail -n 1 "${LOG}"`
-  log "{\"status\": \"Success\" , \"message\" :  \"log:${errorLog}\" }"
-  exit 0
+	if [ $READ_WRITE != "ro" ]; then
+		#formatting
+		VOLFSTYPE=$(blkid -o udev /dev/${diskname} 2>/dev/null | grep "ID_FS_TYPE" | cut -d"=" -f2 || echo -n "")
+		if [ -z "${VOLFSTYPE}" ]; then
+			echo "`date` INF: disk:${diskname} is not formatted and will be formatted to ${FS_TYPE}" >> $LOG
+			mkfs -t ${FS_TYPE} /dev/${diskname} >/dev/null 2>&1
+			if [ "$?" != "0" ]; then
+				err "{ \"status\": \"Failure\", \"message\": \"Failed to create fs ${FSTYPE} on device ${diskname}\"}"
+				exit 1
+			fi
+		else
+			echo "`date` INF: disk:${diskname} has fstype:${VOLFSTYPE} and will not be formatted" >> $LOG
+		fi
+	fi
+
+	#mounting
+	echo "`date` EXEC: /bin/mount  ${read_only_param} /dev/${diskname} "${MNTPATH}"" >>$LOG
+	/bin/mount  ${read_only_param} /dev/$diskname "${MNTPATH}" >>$LOG 2>&1
+	if [ "$?" != "0" ]; then
+		errorLog=`tail -n 1 "${LOG}"`
+		err "{ \"status\": \"Failure\", \"message\": \"Failed to mount device /dev/${diskname} at ${MNTPATH}, accountname:${ACCOUNTNAME}, error log:${errorLog}\"}"
+		exit 1
+	fi
+
+	errorLog=`tail -n 1 "${LOG}"`
+	log "{\"status\": \"Success\",\"message\":\"log:${errorLog}\" }"
+	exit 0
 }
 
 unmount() {
-  MNTPATH="$1"
+	MNTPATH="$1"
 
-  if ! ismounted ; then
-    log '{"status": "Success"}'
-    exit 0
-  fi
+	if ! ismounted ; then
+		log '{"status": "Success"}'
+		exit 0
+	fi
 
-  #find device name
-  local devname=`findmnt -n -o SOURCE ${MNTPATH}`
-  if [ ${#devname} -lt 5 ]; then
-    echo "INF: mount path:${MNTPATH} has no mounts" >> $LOG
-    log '{"status": "Success"}'
-    exit 0
-  fi
+	#find device name
+	devname=`findmnt -n -o SOURCE ${MNTPATH}`
+	if [ ${#devname} -lt 5 ]; then
+		echo "`date` INF: mount path:${MNTPATH} has no mounts" >> $LOG
+		log '{"status": "Success"}'
+		exit 0
+	fi
 
-  echo "EXEC: umount $MNTPATH, devname: $devname" >>$LOG
-  /bin/umount $MNTPATH >> $LOG 2>&1
-  if [ "$?" != "0" ]; then
-    errorLog=`tail -n 1 "${LOG}"`
-    err '{ "status": "Failed", "message": "Failed to unmount volume at '${MNTPATH}'"}, error log:'${errorLog}''
-    exit 1
-  fi
+	echo "`date` EXEC: umount $MNTPATH, devname: $devname" >>$LOG
+	/bin/umount $MNTPATH >> $LOG 2>&1
+	if [ "$?" != "0" ]; then
+		errorLog=`tail -n 1 "${LOG}"`
+		err '{ "status": "Failed", "message": "Failed to unmount volume at '${MNTPATH}'"}, error log:'${errorLog}''
+		exit 1
+	fi
 
-  echo "EXEC: rmdir ${MNTPATH}" >> $LOG
-  rmdir "${MNTPATH}" >> $LOG 2>&1
+	echo "`date` EXEC: rmdir ${MNTPATH}" >> $LOG
+	rmdir "${MNTPATH}" >> $LOG 2>&1
 
-  local diskname=`echo $devname | cut -d '/' -f3`
-  if [ ${#diskname} -lt 5 ]; then
-    err '{ "status": "Failure", "message": "Failed to parse disk name according to devname('${devname}'), returned disk name: '${diskname}, mountPath: '${MNTPATH}'''
-    exit 1
-  fi
+	diskname=`echo $devname | cut -d '/' -f3`
+	if [ ${#diskname} -lt 5 ]; then
+		err '{ "status": "Failure", "message": "Failed to parse disk name according to devname('${devname}'), returned disk name: '${diskname}, mountPath: '${MNTPATH}'''
+		exit 1
+	fi
 
-  echo "EXEC:dyskctl unmount -d $diskname" >>$LOG
-  ${DYSKCTL} unmount -d $diskname >>$LOG 2>&1
-  if [ $? -ne 0 ]; then
-    errorLog=`tail -n 1 "${LOG}"`
-    err "{ \"status\": \"Failed\", \"message\": \"Failed to dyskctl unmount disk(${diskname}) error log: ${errorLog}\"}"
-    exit 1
-  fi
+	echo "`date` EXEC:dyskctl unmount -d $diskname" >>$LOG
+	${DYSKCTL} unmount -d $diskname >>$LOG 2>&1
+	if [ $? -ne 0 ]; then
+		errorLog=`tail -n 1 "${LOG}"`
+		err "{ \"status\": \"Failed\", \"message\": \"Failed to dyskctl unmount disk(${diskname}) error log: ${errorLog}\"}"
+		exit 1
+	fi
 
-  log '{"status": "Success"}'
-  exit 0
+	log '{"status": "Success"}'
+	exit 0
 }
 
 ## ---------------
@@ -195,27 +166,25 @@ unmount() {
 op=$1
 
 if [ "$op" = "init" ]; then
-  log '{"status": "Success", "capabilities": {"attach": false}}'
-  exit 0
+	log '{"status": "Success", "capabilities": {"attach": false}}'
+	exit 0
 fi
 
 if [ $# -lt 2 ]; then
-  usage
+	usage
 fi
 
 shift
 
 case "$op" in
-  mount)
-    mount $*
-    ;;
-  unmount)
-    unmount $*
-    ;;
-  *)
-  usage
+	mount)
+		mount $*
+		;;
+	unmount)
+		unmount $*
+		;;
+	*)
+	usage
 esac
 
 exit 1
-
-

--- a/kubernetes/nginx-flex-dysk-pvc.yaml
+++ b/kubernetes/nginx-flex-dysk-pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-flex-dysk
+spec:
+  containers:
+  - name: nginx-flex-dysk
+    image: nginx
+    volumeMounts:
+    - name: flexvol-mount
+      mountPath: /data
+  volumes:
+  - name: flexvol-mount
+    persistentVolumeClaim:
+      claimName: pvc-dysk-flexvol

--- a/kubernetes/pv-dysk-flexvol.yaml
+++ b/kubernetes/pv-dysk-flexvol.yaml
@@ -1,17 +1,14 @@
 apiVersion: v1
-kind: Pod
+kind: PersistentVolume
 metadata:
-  name: nginx-flex-dysk
+  name: pv-dysk-flexvol
 spec:
-  containers:
-  - name: nginx-flex-dysk
-    image: nginx
-    volumeMounts:
-    - name: test
-      mountPath: /data
-  volumes:
-  - name: test
-    flexVolume:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  flexVolume:
       driver: "azure/dysk"
       readOnly: false
       fsType: ext4

--- a/kubernetes/pvc-dysk-flexvol.yaml
+++ b/kubernetes/pvc-dysk-flexvol.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvc-dysk-flexvol
+spec:
+  accessModes:
+  - ReadWriteOnce  #also supports ReadOnlyMany
+  resources:
+    requests:
+      storage: 10Gi
+  volumeName: pv-dysk-flexvol
+  storageClassName: ""


### PR DESCRIPTION
This PR supports both RWO & ROX access modes, there are a few main design changes compared to previous PR:
 - don't allow `auto-create` in dysk FlexVolume driver since FlexVolume does not support dynamic provisioning, so we should let user create vhd in advance, and brings the vhd for this driver, that's called static provioning, and that's the correct behavior of FlexVolume driver. 
 - use PV/PVC to support ROX access modes, use could use one ROX PVC for multiple pods.

BTW, dynamic provisioning feature is covered in CSI volume, and I will bring dysk CSI volume next.
Pls also update image `khenidak/dysk-installer:0.5` since it's still using `dysk~dysk` dir instead of `azure~dysk`, you may update the image version then.

@khenidak 