### PR TITLE
Allow mounting with a SAS without account key substitution

### DIFF
--- a/dyskctl/cmd/cmds.go
+++ b/dyskctl/cmd/cmds.go
@@ -15,6 +15,7 @@ import (
 var (
 	storageAccountName string
 	storageAccountKey  string
+	storageAccountSas  string
 
 	filePath string
 
@@ -194,7 +195,12 @@ dyskctl mount-file --file {path to file}`,
 				printError(err)
 				os.Exit(1)
 			}
-			dyskClient := client.CreateClientWithSas(d.AccountName, d.Sas)
+
+			// TODO: DESIGN: with the current unmarshalling, there's no way to tell whether or not
+			// the SAS we pass along is an account key or an actual SAS. Consider adding an additional
+			// property to client.Dysk.
+			// For now we assume a conversion is always required for a key.
+			dyskClient := client.CreateClientWithSas(d.AccountName, d.Sas, "")
 			err = dyskClient.Mount(&d, false, false)
 			if nil != err {
 				printError(err)
@@ -265,6 +271,7 @@ func init() {
 	// MOUNT //
 	mountCmd.PersistentFlags().StringVarP(&storageAccountName, "account", "a", "", "Azure storage account name")
 	mountCmd.PersistentFlags().StringVarP(&storageAccountKey, "key", "k", "", "Azure storage account key")
+	mountCmd.PersistentFlags().StringVarP(&storageAccountSas, "sas", "s", "", "Azure storage SAS. If specified, Azure account key is not required. Optional.")
 	mountCmd.PersistentFlags().StringVarP(&pageBlobName, "pageblob-name", "p", "", "Azure storage page blob name")
 	mountCmd.PersistentFlags().StringVarP(&container, "container-name", "c", "dysks", "Azure storage blob container name)")
 	mountCmd.PersistentFlags().StringVarP(&deviceName, "device-name", "d", "", "block device name. if empty a random name will be used")

--- a/dyskctl/cmd/utils.go
+++ b/dyskctl/cmd/utils.go
@@ -10,16 +10,26 @@ import (
 	"github.com/khenidak/dysk/pkg/client"
 )
 
+const (
+	defaultDyskSize = 2
+)
+
 func mount_create() {
 	var err error
-	dyskClient := client.CreateClient(storageAccountName, storageAccountKey)
+	var dyskClient client.DyskClient
+
+	if storageAccountSas == "" {
+		dyskClient = client.CreateClient(storageAccountName, storageAccountKey)
+	} else {
+		dyskClient = client.CreateClientWithSas(storageAccountName, storageAccountKey, storageAccountSas)
+	}
 
 	if "" == deviceName {
 		deviceName = getRandomDyskName()
 	}
 
 	if 0 == size {
-		size = 2
+		size = defaultDyskSize
 	}
 
 	if autoCreate {

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,14 @@ Type                            Name                            VHD             
 RW                              dysk1cmwC5uU                    Yes                             2                               dyskdemo                        /dysks/dysk1cmwC5uU.vhd
 ```
 
+Mount an existing Azure Page Blob (with a SAS):
+```
+sudo dyskctl mount -a {STORAGE ACCOUNT NAME} -s {SAS URL} -p dyskHrcjoIj4.vhd -l -b
+
+## SAS URLs are currently using this format:
+## "se=2020-04-05T20%3A13%3A24Z&sig=foo%3D&sp=rw&sr=b&sv=2017-04-01"
+```
+
 If you are seeing error `storage: service returned error: StatusCode=409, ErrorCode=LeaseAlreadyPresent, ErrorMessage=There is already a lease present.`, you can set the `--break-lease` flag to `true` to break the existing lease.
 ```
 sudo dyskctl mount -a {STORAGE ACCOUNT NAME} -k {STORAGE ACCOUNT KEY} -c {CONTAINER NAME} -d {DISK NAME} -i {LEASE ID} -b true


### PR DESCRIPTION
This probably reads weirdly and it's pretty hacky to me. I think there needs to be some more in-depth refactoring done to better distinguish between "account key" and "sas" - at the end of the day the module only cares about the sas, but the client's terminology isn't consistent right now.

For example, since `client.dysk` only has a `sas` property which is actually a storage key, there's no way to distinguish between an actual SAS and the account key during `unmount`. It just leads to lots of `if` statements everywhere for odd cases.